### PR TITLE
Manjaro light icons for Arch-Update

### DIFF
--- a/res/icons/arch-update-mlight.svg
+++ b/res/icons/arch-update-mlight.svg
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.2"
+   width="10cm"
+   height="10cm"
+   id="svg2"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25, custom)"
+   sodipodi:docname="arch-update-mlight.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25098039"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3440"
+     inkscape:window-height="1412"
+     id="namedview15"
+     showgrid="false"
+     inkscape:showpageshadow="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="3.2385"
+     inkscape:cx="189.13077"
+     inkscape:cy="188.97638"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="text594"
+     inkscape:pagecheckerboard="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:deskcolor="#585858"
+     inkscape:document-units="cm"
+     inkscape:lockguides="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid837"
+       originx="18.181768"
+       originy="18.416125"
+       spacingy="1"
+       spacingx="1"
+       units="cm"
+       visible="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     aria-label="®"
+     id="text594"
+     style="font-size:140.705px;line-height:1.25;letter-spacing:0px;word-spacing:0px;fill:#4f4f4f;stroke-width:3.51762"
+     transform="matrix(0.31550702,0,0,0.31550702,-86.515514,230.48643)"
+     inkscape:label="Manjaro Logo vertical">
+    <path
+       id="rect1340-7"
+       style="font-size:140.705px;line-height:1.25;letter-spacing:0px;word-spacing:0px;fill:#35bf5c;stroke-width:46.074;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;paint-order:stroke fill markers;fill-opacity:1"
+       d="m 458.50643,-637.19183 c -51.04978,0 -92.14777,41.09788 -92.14777,92.14796 v 829.3307 c 0,51.05002 41.09799,92.14791 92.14777,92.14791 h 184.29602 v -737.18315 h 368.59115 v -276.44342 z m 645.03517,0 V 376.43474 h 184.2959 c 51.0496,0 92.1475,-41.09789 92.1475,-92.14791 v -829.3307 c 0,-51.05008 -41.0979,-92.14796 -92.1475,-92.14796 z m -368.59139,368.59134 v 645.03523 h 276.44339 v -645.03523 z"
+       inkscape:label="M" />
+    <use
+       x="0"
+       y="0"
+       xlink:href="#rect1340-7"
+       id="use1"
+       inkscape:highlight-color="#ffffff"
+       style="font-size:140.705px;line-height:1.25;letter-spacing:0px;word-spacing:0px;fill:#000000;stroke:#000000;stroke-width:3.51762" />
+    <path
+       style="fill:#ffffff;stroke:#000000;stroke-width:1.16706"
+       d="M 55.109488,348.92259 C 43.42604,347.688 33.967754,339.68862 30.203405,327.85816 l -0.714163,-2.24445 -0.09316,-134.78462 C 29.32733,91.353908 29.394798,55.452066 29.653626,53.783138 31.359099,42.786216 39.655706,33.679771 50.88823,30.475809 l 2.377171,-0.678063 89.624829,-0.0803 89.62482,-0.0803 v 43.387387 43.387387 h -58.20596 -58.20596 v 116.41192 116.41192 l -29.411761,-0.0419 c -16.17647,-0.0231 -30.388317,-0.14509 -31.581881,-0.27123 z"
+       id="path1"
+       transform="matrix(3.1695016,0,0,3.1695016,274.21106,-730.52711)" />
+    <path
+       style="fill:#ffffff;stroke:#000000;stroke-width:1.16706"
+       d="M 145.4377,247.49112 V 145.74649 h 43.53868 43.53867 V 247.49112 349.23576 H 188.97638 145.4377 Z"
+       id="path3"
+       transform="matrix(3.1695016,0,0,3.1695016,274.21106,-730.52711)" />
+    <path
+       style="fill:#ffffff;stroke:#000000;stroke-width:1.16706"
+       d="M 261.84962,189.43113 V 29.626496 l 31.41887,0.08863 c 31.24721,0.08815 31.43185,0.09232 33.79604,0.763688 10.01861,2.845039 17.42646,10.063842 20.53147,20.007521 l 0.86779,2.779065 v 136.01976 136.01977 l -0.73006,2.47027 c -2.98371,10.0958 -10.77561,17.79747 -20.62113,20.38231 -3.60841,0.94735 -7.6783,1.06759 -36.31439,1.07291 l -28.94859,0.005 z"
+       id="path5"
+       transform="matrix(3.1695016,0,0,3.1695016,274.21106,-730.52711)" />
+    <path
+       class="cls-1"
+       d="m 706.5564,60.526919 c 0,-0.747633 -12.198,10.146667 -12.198,9.399014 h -71.0635 l 123.3254,-136.39218 124.8923,136.39218 h -71.0633 c 0,0.747653 -15.5556,-10.146647 -15.5556,-9.399014 0,130.090581 105.3078,235.295171 235.1243,235.295171 58.7526,0 112.6936,-21.78856 153.5411,-57.67558 l 52.2622,59.17087 c -55.5075,48.27664 -127.354,77.11448 -205.6917,77.11448 -173.1253,0 -313.4612,-140.98485 -313.4612,-314.011737 z"
+       id="path4"
+       style="font-size:140.705px;line-height:1.25;letter-spacing:0px;word-spacing:0px;fill:#dfdfdf;stroke:#000000;stroke-width:11.9792;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="font-size:140.705px;line-height:1.25;letter-spacing:0px;word-spacing:0px;fill:#dfdfdf;fill-opacity:1;stroke:#000000;stroke-width:11.9792;stroke-dasharray:none"
+       d="m 1304.1966,157.70454 c -6.6693,-7.26122 -34.2731,-37.40868 -61.342,-66.994371 l -49.2162,-53.792194 34.5857,-0.297224 34.5855,-0.297213 7.4039,4.652654 c 4.0721,2.558977 7.7466,4.322059 8.1657,3.917928 1.3909,-1.341611 -1.9828,-34.654503 -4.9197,-48.5782748 C 1260.47,-65.266113 1223.2569,-119.262 1170.2449,-153.44759 c -69.2905,-44.6832 -157.3508,-49.58371 -231.5444,-12.88528 -13.7689,6.81056 -27.0165,15.1783 -39.8425,25.16644 -5.2343,4.07611 -9.6854,7.23639 -9.8914,7.02286 -0.2062,-0.21339 -11.7195,-13.24695 -25.5855,-28.96315 l -25.211,-28.57487 5.045,-4.34977 c 2.7747,-2.39236 10.0117,-7.9719 16.0822,-12.39893 93.1121,-67.90439 215.7174,-78.89428 319.4971,-28.63851 102.4574,49.61541 171.3807,153.382395 176.2166,265.301989 0.4062,9.398901 1.0591,17.088941 1.451,17.088941 0.392,0 3.2433,-2.017047 6.3364,-4.482355 l 5.6237,-4.482331 h 34.9452 34.9451 l -2.9566,3.08161 c -1.6261,1.694895 -24.5502,27.034111 -50.9425,56.309421 -48.4696,53.764435 -62.7153,69.510365 -66.1867,73.157605 -1.8004,1.89141 -2.5651,1.28082 -14.03,-11.20179 z"
+       id="path2" />
+  </g>
+</svg>

--- a/res/icons/arch-update_updates-available-mlight.svg
+++ b/res/icons/arch-update_updates-available-mlight.svg
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.2"
+   width="10cm"
+   height="10cm"
+   id="svg2"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25, custom)"
+   sodipodi:docname="arch-update_updates-available-mlight.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25098039"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3440"
+     inkscape:window-height="1412"
+     id="namedview15"
+     showgrid="false"
+     inkscape:showpageshadow="false"
+     fit-margin-top="0"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     fit-margin-bottom="0"
+     inkscape:zoom="3.2385"
+     inkscape:cx="189.13077"
+     inkscape:cy="188.97638"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="text594"
+     inkscape:pagecheckerboard="0"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:deskcolor="#585858"
+     inkscape:document-units="cm"
+     inkscape:lockguides="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid837"
+       originx="18.181768"
+       originy="18.416125"
+       spacingy="1"
+       spacingx="1"
+       units="cm"
+       visible="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     aria-label="®"
+     id="text594"
+     style="font-size:140.705px;line-height:1.25;letter-spacing:0px;word-spacing:0px;fill:#4f4f4f;stroke-width:3.51762"
+     transform="matrix(0.31550702,0,0,0.31550702,-86.515514,230.48643)"
+     inkscape:label="Manjaro Logo vertical">
+    <path
+       id="rect1340-7"
+       style="font-size:140.705px;line-height:1.25;letter-spacing:0px;word-spacing:0px;fill:#35bf5c;stroke-width:46.074;fill-rule:evenodd;stroke-linecap:round;stroke-linejoin:round;paint-order:stroke fill markers;fill-opacity:1"
+       d="m 458.50643,-637.19183 c -51.04978,0 -92.14777,41.09788 -92.14777,92.14796 v 829.3307 c 0,51.05002 41.09799,92.14791 92.14777,92.14791 h 184.29602 v -737.18315 h 368.59115 v -276.44342 z m 645.03517,0 V 376.43474 h 184.2959 c 51.0496,0 92.1475,-41.09789 92.1475,-92.14791 v -829.3307 c 0,-51.05008 -41.0979,-92.14796 -92.1475,-92.14796 z m -368.59139,368.59134 v 645.03523 h 276.44339 v -645.03523 z"
+       inkscape:label="M" />
+    <use
+       x="0"
+       y="0"
+       xlink:href="#rect1340-7"
+       id="use1"
+       inkscape:highlight-color="#ffffff"
+       style="font-size:140.705px;line-height:1.25;letter-spacing:0px;word-spacing:0px;fill:#000000;stroke:#000000;stroke-width:3.51762" />
+    <path
+       style="fill:#ffffff;stroke:#000000;stroke-width:1.16706"
+       d="M 55.109488,348.92259 C 43.42604,347.688 33.967754,339.68862 30.203405,327.85816 l -0.714163,-2.24445 -0.09316,-134.78462 C 29.32733,91.353908 29.394798,55.452066 29.653626,53.783138 31.359099,42.786216 39.655706,33.679771 50.88823,30.475809 l 2.377171,-0.678063 89.624829,-0.0803 89.62482,-0.0803 v 43.387387 43.387387 h -58.20596 -58.20596 v 116.41192 116.41192 l -29.411761,-0.0419 c -16.17647,-0.0231 -30.388317,-0.14509 -31.581881,-0.27123 z"
+       id="path1"
+       transform="matrix(3.1695016,0,0,3.1695016,274.21106,-730.52711)" />
+    <path
+       style="fill:#ffffff;stroke:#000000;stroke-width:1.16706"
+       d="M 145.4377,247.49112 V 145.74649 h 43.53868 43.53867 V 247.49112 349.23576 H 188.97638 145.4377 Z"
+       id="path3"
+       transform="matrix(3.1695016,0,0,3.1695016,274.21106,-730.52711)" />
+    <path
+       style="fill:#ffffff;stroke:#000000;stroke-width:1.16706"
+       d="M 261.84962,189.43113 V 29.626496 l 31.41887,0.08863 c 31.24721,0.08815 31.43185,0.09232 33.79604,0.763688 10.01861,2.845039 17.42646,10.063842 20.53147,20.007521 l 0.86779,2.779065 v 136.01976 136.01977 l -0.73006,2.47027 c -2.98371,10.0958 -10.77561,17.79747 -20.62113,20.38231 -3.60841,0.94735 -7.6783,1.06759 -36.31439,1.07291 l -28.94859,0.005 z"
+       id="path5"
+       transform="matrix(3.1695016,0,0,3.1695016,274.21106,-730.52711)" />
+    <path
+       class="cls-2"
+       d="m 1066.0185,-189.15987 c -1.6248,0 -3.2494,-0.1361 -4.8033,-0.1361 -85.6116,0 -161.4046,40.82349 -208.0247,103.555599 -30.6562,41.163721 -48.7392,91.7848758 -48.7392,146.55643 0,138.119501 114.9963,250.111981 256.8345,250.111981 141.8381,0 256.8344,-111.99248 256.8344,-250.111981 0,-138.119574 -112.3827,-247.458509 -251.9605,-249.975959 z"
+       id="path3-3"
+       style="fill:#f93a30;stroke-width:0px" />
+  </g>
+</svg>

--- a/src/lib/config.sh
+++ b/src/lib/config.sh
@@ -48,7 +48,7 @@ if [ -f "${config_file}" ]; then
 
 	# Check the "TrayIconStyle" option in arch-update.conf
 	# shellcheck disable=SC2034
-	tray_icon_style=$(grep -E '^[[:space:]]*TrayIconStyle[[:space:]]*=[[:space:]]*(light|dark|blue)[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
+	tray_icon_style=$(grep -E '^[[:space:]]*TrayIconStyle[[:space:]]*=[[:space:]]*(light|dark|blue|mlight|mdark|mgreen|mmaia)[[:space:]]*$' "${config_file}" 2> /dev/null | awk -F '=' '{print $2}' | tr -d '[:space:]')
 fi
 
 # Set the default / fallback value for options that require it (if the arch-update.conf configuration file doesn't exists, if the concerned option is commented or if the set value is invalid) 


### PR DESCRIPTION
### Description

- Manjaro light icons for Arch-Update.
- Add mlight, mdark, mgreen, mmaia in tray_icon_style.